### PR TITLE
fix: open resume link in new tab safely

### DIFF
--- a/src/app/components/fab/index.tsx
+++ b/src/app/components/fab/index.tsx
@@ -5,7 +5,11 @@ import { StyledFabLink } from './styled';
 
 export const FAB = () => {
     return (
-        <StyledFabLink href="https://cv.ptrcklehmann.com" target="__blank">
+        <StyledFabLink
+            href="https://cv.ptrcklehmann.com"
+            target="_blank"
+            rel="noopener noreferrer"
+        >
             <FileUser />
             Resume
         </StyledFabLink>


### PR DESCRIPTION
## Summary
- open Resume link in a new tab instead of new window
- prevent reverse tabnabbing by adding rel to link

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896f6cad1c883209c701e8f864b2ad7