### PR TITLE
Use en_GB locale for portfolio metadata

### DIFF
--- a/src/app/(portfolio)/page.tsx
+++ b/src/app/(portfolio)/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata(): Promise<Metadata> {
             title: `${RESUME_OG_DATA.name} - Frontend Developer`,
             description: RESUME_OG_DATA.about,
             type: 'website',
-            locale: 'en_UK',
+            locale: 'en_GB',
             siteName: 'Patrick Lehmann - Frontend Developer',
             url: 'https://ptrcklehmann.com',
             images: [


### PR DESCRIPTION
## Summary
- use `en_GB` locale for open graph metadata on portfolio page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896f83955f88320985e16e5d0af25b2