### PR TITLE
refactor: simplify day name logic

### DIFF
--- a/src/app/components/main/animated-message.tsx
+++ b/src/app/components/main/animated-message.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { TypeAnimation } from 'react-type-animation';
 import { AnimatedMessageContainer, DesktopHiddenBr } from './styled';
 
@@ -21,7 +20,7 @@ const scrambleTexts = adjectives.flatMap(item => [item, 1800]);
 const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 export const AnimatedMessage = () => {
-    const dayname = useMemo(() => weekdays[new Date().getDay()], []);
+    const dayname = weekdays[new Date().getDay()];
 
     return (
         <AnimatedMessageContainer>


### PR DESCRIPTION
## Summary
- simplify AnimatedMessage component by computing `dayname` directly and removing `useMemo`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896f83814c883208edd2dfc21dc480d